### PR TITLE
Add industries overview page

### DIFF
--- a/dash/pages/overview.py
+++ b/dash/pages/overview.py
@@ -1,76 +1,89 @@
+"""نمای کلی صنایع استان خراسان رضوی.
+
+این صفحه داده‌های خلاصه‌ی صنایع را از فایل ``data/industries_summary.json``
+خوانده و در قالب نمودارهای دایره‌ای، میله‌ای و جدول نمایش می‌دهد."""
+
 import json
 import pandas as pd
-import dash
-from dash import html, dcc, dash_table
-from dash.dash_table import FormatTemplate
+from dash import html, dcc, dash_table, register_page
 import plotly.express as px
 
-# Register the page for Dash's multi-page architecture
+register_page(__name__, path="/overview", name="نمای کلی صنایع")
 
-dash.register_page(__name__, path="/overview", name="نمای کلی صنایع")
-
-# Load data from JSON file
+# ---------------------------------------------------------------------------
+# Load and prepare data
+# ---------------------------------------------------------------------------
 with open("data/industries_summary.json", encoding="utf-8") as f:
     data = json.load(f)
 
-# Convert to DataFrame
-industries_df = pd.DataFrame(data)
+df = pd.DataFrame(data)
 
-# Pie chart: number of units per industry (ISIC two-digit code)
+# Map possible old column names to the expected ones
+rename_map = {
+    "industry": "industry_name",
+    "isic": "isic_code",
+    "units": "unit_count",
+}
+for old, new in rename_map.items():
+    if old in df.columns and new not in df.columns:
+        df = df.rename(columns={old: new})
+
+# Pie chart: distribution of units by industry
 pie_fig = px.pie(
-    industries_df,
-    names="isic",
-    values="units",
-    title="تعداد واحدهای هر صنعت بر اساس کد ISIC"
+    df,
+    names="industry_name",
+    values="unit_count",
+    title="توزیع تعداد واحدها بر اساس صنعت",
 )
 
-# Bar chart: sum of consumption if column exists
-bar_fig = None
-if "consumption" in industries_df.columns:
-    bar_df = industries_df.groupby("isic", as_index=False)["consumption"].sum()
-    bar_fig = px.bar(
-        bar_df,
-        x="isic",
-        y="consumption",
-        title="مصرف برق تخمینی هر صنعت"
-    )
+# Bar chart: units per industry ordered descending
+bar_df = df.sort_values("unit_count", ascending=False)
+bar_fig = px.bar(
+    bar_df,
+    x="industry_name",
+    y="unit_count",
+    title="مقایسه تعداد واحدها در صنایع",
+)
+bar_fig.update_layout(xaxis_title="نام صنعت", yaxis_title="تعداد واحدها")
 
-# Table data: total units and consumption share
-industries_df["share"] = industries_df["units"] / industries_df["units"].sum()
+# DataTable columns
+table_columns = [
+    {"name": "نام صنعت", "id": "industry_name"},
+    {"name": "کد ISIC", "id": "isic_code"},
+    {"name": "تعداد واحدها", "id": "unit_count"},
+]
 
-layout = html.Div([
-    html.H1("نمای کلی صنایع خراسان رضوی", className="text-2xl mb-4"),
-    html.Div([
-        html.Div([
-            html.H2("توزیع واحدهای صنعتی", className="text-xl mb-2"),
-            dcc.Graph(figure=pie_fig),
-            html.P("نمودار بالا تعداد واحدهای فعال در هر صنعت را نمایش می‌دهد.")
-        ], className="bg-white shadow rounded p-4"),
-        html.Div([
-            html.H2("مصرف برق صنایع", className="text-xl mb-2"),
-            dcc.Graph(figure=bar_fig) if bar_fig else html.P("ستون مصرف در داده‌ها موجود نیست."),
-            html.P("میزان مصرف برق تخمینی صنایع نشان داده شده است.")
-        ], className="bg-white shadow rounded p-4"),
-        html.Div([
-            html.H2("جدول خلاصه صنایع", className="text-xl mb-2"),
-            dash_table.DataTable(
-                data=industries_df.to_dict("records"),
-                columns=[
-                    {"name": "کد ISIC", "id": "isic"},
-                    {"name": "صنعت", "id": "industry"},
-                    {"name": "تعداد واحدها", "id": "units"},
-                ]
-                + (
-                    [{"name": "مصرف", "id": "consumption", "type": "numeric"}]
-                    if "consumption" in industries_df.columns else []
-                )
-                + [
-                    {"name": "سهم نسبی", "id": "share", "type": "numeric", "format": FormatTemplate.percentage(2)}
-                ],
-                style_table={"overflowX": "auto"},
-                style_cell={"textAlign": "center", "fontFamily": "Vazirmatn"}
-            ),
-            html.P("جدول بالا خلاصه‌ای از تعداد، مصرف و سهم نسبی صنایع را نشان می‌دهد.")
-        ], className="bg-white shadow rounded p-4")
-    ], className="space-y-6")
-], className="container mx-auto py-4 space-y-8")
+# ---------------------------------------------------------------------------
+# Layout
+# ---------------------------------------------------------------------------
+layout = html.Div(
+    [
+        html.H1("نمای کلی صنایع خراسان رضوی", className="text-2xl mb-4"),
+        html.Div(
+            [
+                html.Div(
+                    [html.H2("توزیع واحدها بر اساس صنعت", className="text-xl mb-2"), dcc.Graph(figure=pie_fig)],
+                    className="bg-white shadow rounded p-4",
+                ),
+                html.Div(
+                    [html.H2("مقایسه تعداد واحدها", className="text-xl mb-2"), dcc.Graph(figure=bar_fig)],
+                    className="bg-white shadow rounded p-4",
+                ),
+                html.Div(
+                    [
+                        html.H2("جدول اطلاعات صنایع", className="text-xl mb-2"),
+                        dash_table.DataTable(
+                            data=df.to_dict("records"),
+                            columns=table_columns,
+                            style_table={"overflowX": "auto"},
+                            style_cell={"textAlign": "center", "fontFamily": "Vazirmatn"},
+                        ),
+                    ],
+                    className="bg-white shadow rounded p-4",
+                ),
+            ],
+            className="space-y-6",
+        ),
+    ],
+    className="container mx-auto py-4 space-y-8",
+)

--- a/pages/overview.py
+++ b/pages/overview.py
@@ -1,24 +1,26 @@
-"""نمای کلی صنایع استان خراسان رضوی.
+"""نمای کلی بازار صنایع استان خراسان رضوی.
 
-این صفحه داده‌های خلاصه‌ی صنایع را از فایل ``data/industries_summary.json``
-خوانده و در قالب نمودارهای دایره‌ای، میله‌ای و جدول نمایش می‌دهد."""
+این صفحه داده‌ها را از فایل ``data/industries_summary.json`` خوانده و
+نمودارهای دایره‌ای و میله‌ای و نیز جدول اطلاعات را نمایش می‌دهد.
+"""
 
 import json
 import pandas as pd
 from dash import html, dcc, dash_table, register_page
 import plotly.express as px
 
+# ثبت صفحه در ساختار چندصفحه‌ای Dash
 register_page(__name__, path="/overview", name="نمای کلی صنایع")
 
 # ---------------------------------------------------------------------------
-# Load and prepare data
+# بارگذاری و آماده‌سازی داده‌ها
 # ---------------------------------------------------------------------------
 with open("data/industries_summary.json", encoding="utf-8") as f:
     data = json.load(f)
 
 df = pd.DataFrame(data)
 
-# Map possible old column names to the expected ones
+# سازگارسازی نام ستون‌ها در صورت وجود نام‌های قدیمی
 rename_map = {
     "industry": "industry_name",
     "isic": "isic_code",
@@ -28,7 +30,7 @@ for old, new in rename_map.items():
     if old in df.columns and new not in df.columns:
         df = df.rename(columns={old: new})
 
-# Pie chart: distribution of units by industry
+# نمودار دایره‌ای: توزیع تعداد واحدها بر اساس صنعت
 pie_fig = px.pie(
     df,
     names="industry_name",
@@ -36,7 +38,7 @@ pie_fig = px.pie(
     title="توزیع تعداد واحدها بر اساس صنعت",
 )
 
-# Bar chart: units per industry ordered descending
+# نمودار میله‌ای: تعداد واحدها به ترتیب نزولی
 bar_df = df.sort_values("unit_count", ascending=False)
 bar_fig = px.bar(
     bar_df,
@@ -46,7 +48,7 @@ bar_fig = px.bar(
 )
 bar_fig.update_layout(xaxis_title="نام صنعت", yaxis_title="تعداد واحدها")
 
-# DataTable columns
+# ستون‌های جدول DataTable
 table_columns = [
     {"name": "نام صنعت", "id": "industry_name"},
     {"name": "کد ISIC", "id": "isic_code"},
@@ -54,7 +56,7 @@ table_columns = [
 ]
 
 # ---------------------------------------------------------------------------
-# Layout
+# چیدمان صفحه
 # ---------------------------------------------------------------------------
 layout = html.Div(
     [
@@ -62,11 +64,17 @@ layout = html.Div(
         html.Div(
             [
                 html.Div(
-                    [html.H2("توزیع واحدها بر اساس صنعت", className="text-xl mb-2"), dcc.Graph(figure=pie_fig)],
+                    [
+                        html.H2("توزیع واحدها بر اساس صنعت", className="text-xl mb-2"),
+                        dcc.Graph(figure=pie_fig),
+                    ],
                     className="bg-white shadow rounded p-4",
                 ),
                 html.Div(
-                    [html.H2("مقایسه تعداد واحدها", className="text-xl mb-2"), dcc.Graph(figure=bar_fig)],
+                    [
+                        html.H2("مقایسه تعداد واحدها", className="text-xl mb-2"),
+                        dcc.Graph(figure=bar_fig),
+                    ],
                     className="bg-white shadow rounded p-4",
                 ),
                 html.Div(


### PR DESCRIPTION
## Summary
- add an overview page in `dash/pages/` to visualize industries summary for Khorasan Razavi
  - pie chart of unit distribution
  - bar chart sorted by unit count
  - data table listing all fields

## Testing
- `python -m py_compile dash/pages/overview.py`

------
https://chatgpt.com/codex/tasks/task_e_684276f4d5cc8328a27fa9fa2fb061f5