### PR TITLE
Add industries overview page

### DIFF
--- a/dash/pages/overview.py
+++ b/dash/pages/overview.py
@@ -1,41 +1,49 @@
-
 import dash
-from dash import html, dcc
+from dash import html, dcc, dash_table
 import pandas as pd
 import plotly.express as px
 
+# ثبت صفحه در ساختار چندصفحه‌ای Dash
 dash.register_page(__name__, path="/overview", name="نمای کلی بازار")
 
-# بارگذاری داده‌ها
-df = pd.read_json("data/industries_summary.json")
+# بارگذاری داده‌ها و تطبیق نام ستون‌ها
+_df = pd.read_json("data/industries_summary.json")
+_df = _df.rename(columns={
+    "industry": "industry_name",
+    "isic": "isic_code",
+    "units": "unit_count",
+})
 
-# نمودار پای
-pie_fig = px.pie(df, values='unit_count', names='industry_name', title='درصد توزیع واحدهای فعال به تفکیک صنعت')
+# نمودار پای برای توزیع تعداد واحدهای صنعتی
+pie_fig = px.pie(
+    _df,
+    values="unit_count",
+    names="industry_name",
+    title="درصد توزیع تعداد واحدهای صنعتی",
+)
 
-# نمودار میله‌ای
-bar_fig = px.bar(df.sort_values('unit_count', ascending=False), 
-                 x='industry_name', y='unit_count',
-                 title='تعداد واحدهای صنعتی فعال (مرتب‌شده)',
-                 labels={'industry_name': 'صنعت', 'unit_count': 'تعداد واحد'})
+# نمودار میله‌ای مرتب‌شده بر اساس تعداد واحدها
+sorted_df = _df.sort_values("unit_count", ascending=False)
+bar_fig = px.bar(
+    sorted_df,
+    x="industry_name",
+    y="unit_count",
+    title="تعداد واحدهای صنعتی به تفکیک صنعت",
+    labels={"industry_name": "صنعت", "unit_count": "تعداد واحد"},
+)
 
 layout = html.Div([
     html.H2("نمای کلی بازار صنایع استان خراسان رضوی"),
-
-    html.Div([
-        dcc.Graph(figure=pie_fig)
-    ], style={"marginBottom": "40px"}),
-
-    html.Div([
-        dcc.Graph(figure=bar_fig)
-    ], style={"marginBottom": "40px"}),
-
-    html.Div([
-        html.H4("جدول اطلاعات صنایع"),
-        dash.dash_table.DataTable(
-            data=df.to_dict('records'),
-            columns=[{"name": i, "id": i} for i in df.columns],
-            style_table={"overflowX": "auto"},
-            style_cell={"textAlign": "center"},
-        )
-    ])
+    dcc.Graph(figure=pie_fig),
+    dcc.Graph(figure=bar_fig),
+    dash_table.DataTable(
+        data=_df[["industry_name", "isic_code", "unit_count"]].to_dict("records"),
+        columns=[
+            {"name": "نام صنعت", "id": "industry_name"},
+            {"name": "کد ISIC", "id": "isic_code"},
+            {"name": "تعداد واحد", "id": "unit_count"},
+        ],
+        style_table={"overflowX": "auto"},
+        style_cell={"textAlign": "center"},
+    ),
 ])


### PR DESCRIPTION
## Summary
- update `/dash/pages/overview.py` for a simple Persian dashboard

## Testing
- `python -m py_compile dash/pages/overview.py`


------
https://chatgpt.com/codex/tasks/task_e_684277633b7883288f88b45ef5c57271