### PR TITLE
Fix Dash app startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,4 +12,5 @@ app.layout = dbc.Container(
 )
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    # Dash 3 replaced ``run_server`` with ``run``
+    app.run(debug=True)

--- a/pages/impact_analysis.py
+++ b/pages/impact_analysis.py
@@ -29,7 +29,9 @@ layout = html.Div([
         data=[],
         style_header={"fontWeight": "bold"},
         style_cell={"textAlign": "center"},
-        className="mt-4"
+        # dash_table 3.x does not support the ``className`` argument
+        # ``style_*`` props are used instead for styling
+        style_table={"marginTop": "1rem"}
     ),
 ])
 


### PR DESCRIPTION
## Summary
- remove unsupported `className` arg from `dash_table.DataTable`
- update `app.py` to use new `app.run`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684294c034f483289498e49253ca644e