### PR TITLE
Add trade network demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # دادهٔ خام بزرگ
 data/**
 !data/README.md
+!data/competitors.json
+!data/impact_metrics.csv
+!data/industries_summary.json
+!data/trade_nodes.csv
+!data/trade_edges.csv
 # محیط مجازی
 .venv/

--- a/data/trade_edges.csv
+++ b/data/trade_edges.csv
@@ -1,0 +1,9 @@
+source,target,volume
+IR,CN,500
+IR,IQ,120
+IR,AE,300
+CN,DE,600
+CN,RU,400
+RU,DE,250
+DE,AE,150
+AE,IQ,100

--- a/data/trade_nodes.csv
+++ b/data/trade_nodes.csv
@@ -1,0 +1,7 @@
+id,country,region
+IR,Iran,Asia
+IQ,Iraq,Asia
+CN,China,Asia
+RU,Russia,Europe
+AE,UAE,Middle East
+DE,Germany,Europe

--- a/pages/trade_network.py
+++ b/pages/trade_network.py
@@ -1,0 +1,73 @@
+import dash
+from dash import html
+import dash_cytoscape as cyto
+import pandas as pd
+
+# Register page
+dash.register_page(__name__, name="شبکه تجارت")
+
+# Load data
+nodes_df = pd.read_csv("data/trade_nodes.csv")
+edges_df = pd.read_csv("data/trade_edges.csv")
+
+# Basic colors for regions
+region_colors = {
+    "Asia": "#FFB703",
+    "Europe": "#219EBC",
+    "Middle East": "#8ECAE6",
+}
+
+cy_nodes = [
+    {
+        "data": {
+            "id": row.id,
+            "label": row.country,
+            "color": region_colors.get(row.region, "#ccc"),
+        }
+    }
+    for row in nodes_df.itertuples()
+]
+
+cy_edges = [
+    {
+        "data": {
+            "source": row.source,
+            "target": row.target,
+            "weight": row.volume,
+        }
+    }
+    for row in edges_df.itertuples()
+]
+
+stylesheet = [
+    {
+        "selector": "node",
+        "style": {
+            "label": "data(label)",
+            "background-color": "data(color)",
+            "width": 40,
+            "height": 40,
+            "text-valign": "center",
+            "text-halign": "center",
+        },
+    },
+    {
+        "selector": "edge",
+        "style": {
+            "width": "mapData(weight, 0, 600, 1, 6)",
+            "curve-style": "bezier",
+            "line-color": "#888",
+        },
+    },
+]
+
+layout = html.Div([
+    html.H2("نمونه شبکه تجارت"),
+    cyto.Cytoscape(
+        id="trade-network",
+        layout={"name": "circle"},
+        elements=cy_nodes + cy_edges,
+        stylesheet=stylesheet,
+        style={"width": "100%", "height": "500px"},
+    ),
+])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ dash
 pandas
 plotly
 dash-bootstrap-components
+dash-cytoscape


### PR DESCRIPTION
## Summary
- add sample trade network dataset
- visualize network with Dash Cytoscape on a new page
- allow tracking of new data in `.gitignore`
- add `dash-cytoscape` dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842b25fa6a08328b2161567fe56888d